### PR TITLE
TransactionFinalizers compatibility updates with SFDC 230 release

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,5 +1,4 @@
 {
   "orgName": "kpoorman company",
-  "edition": "Developer",
-  "features": ["TransactionFinalizers"]
+  "edition": "Developer"
 }

--- a/force-app/main/default/classes/Chain.cls
+++ b/force-app/main/default/classes/Chain.cls
@@ -9,7 +9,7 @@ public class Chain implements Finalizer {
 
   public void execute(FinalizerContext context){
     Id parentQueueableJobId = context.getAsyncApexJobId();
-    switch on context.getAsyncApexJobResult() {
+    switch on context.getResult() {
       when SUCCESS {
         if(this.promises.size() > 0){
           Promise next = this.promises.remove(0);
@@ -20,7 +20,7 @@ public class Chain implements Finalizer {
       }
       when UNHANDLED_EXCEPTION {
         System.Debug('Parent Queueable (Job ID: ' + parentQueueableJobId + '): FAILED!');
-        System.Debug('Parent Queueable Exception: ' + context.getAsyncApexJobException().getMessage());
+        System.Debug('Parent Queueable Exception: ' + context.getException().getMessage());
       }
     }    
   }


### PR DESCRIPTION
Since the feature has gone to open beta and no longer requires any explicit opt-in like the pilot did.

You might want to wait for the 230 release to be on more pods (currently only on gs0) before you merge this. 

There were also two FinalizerContext methods that had their names changed during the pilot that needed correction to deploy against 228/230 salesforce versions.